### PR TITLE
Add Stripe donate button

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,16 @@
           <li><a href="https://www.meetup.com/drupalchicago/">Drupal Chicago Meetup group</a></li>
         </ul>
 
+        <script async
+            src="https://js.stripe.com/v3/buy-button.js">
+        </script>
+
+        <stripe-buy-button
+            buy-button-id="buy_btn_1RjBvlEEZHQhopN3lUAg0aIh"
+            publishable-key="pk_live_CbJcSB3XYcY22hzEADj85FbT00Uua6B2EL"
+        >
+        </stripe-buy-button>
+
     </section>
     <footer>
 


### PR DESCRIPTION
Adds a donate button using Stripe's [Payment Links](https://support.stripe.com/questions/how-to-accept-donations-through-stripe).

It should look [like this one](https://donate.stripe.com/bJe4gz3v7d17c6K9RX5EY00) but embedded.

Resolves https://github.com/mosa-chicago/mosa/issues/28