### PR TITLE
Update Decoupled Days description

### DIFF
--- a/src/data/sponsored-communities.json
+++ b/src/data/sponsored-communities.json
@@ -35,7 +35,7 @@
     {
       "name": "Decoupled Days",
       "url": "https://www.decoupleddays.com/",
-      "description": "Conference focused on decoupled and headless Drupal.",
+      "description": "Conference focused on modern open-source web development and headless content and commerce architectures from an open-source perspective.",
       "since": "2024"
     },
     {


### PR DESCRIPTION
Updating description on Decoupled Days to reflect the fact we're not just about decoupled Drupal and are about headless content and commerce from an open-source perspective writ large!